### PR TITLE
Added 'wp_stateless_bucket_link' filter

### DIFF
--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -141,7 +141,7 @@ namespace wpCloud\StatelessMedia {
 
           $file = wp_normalize_path( $metadata[ 'file' ] );
 
-          $bucketLink = 'https://storage.googleapis.com/' . ud_get_stateless_media()->get( 'sm.bucket' );
+          $bucketLink = apply_filters('wp_stateless_bucket_link', 'https://storage.googleapis.com/' . ud_get_stateless_media()->get( 'sm.bucket' ) );
 
           $_metadata = array(
             "width" => isset( $metadata[ 'width' ] ) ? $metadata[ 'width' ] : null,


### PR DESCRIPTION
This filter allows the bucket link to be modified, so that users with custom GCS domains are accommodated.